### PR TITLE
Correction kanban-status 

### DIFF
--- a/packages/backend/src/timeentries/timeentries.service.ts
+++ b/packages/backend/src/timeentries/timeentries.service.ts
@@ -23,7 +23,11 @@ export class TimeentriesService {
   }
 
   async findAll(): Promise<TimeEntry[]> {
-    return await this.timeEntriesRepository.find({ relations: ['task'] });
+    return await this.timeEntriesRepository.find({
+      relations: {
+        taskassignment: { userproject: { user: true } },
+      },
+    });
   }
 
   async findOne(id: string): Promise<TimeEntry> {

--- a/packages/frontend/src/app/kanban-status/kanban-status.component.ts
+++ b/packages/frontend/src/app/kanban-status/kanban-status.component.ts
@@ -52,12 +52,15 @@ export class KanbanStatusComponent implements OnInit {
 
     deleteKanbanStatus(){
         const kanbanObserver = {
+            next: (result: any) => {
+                console.log(`${result}`);
+                this.toastService.success(`Column deleted ! ${result}`);
+            },
             error : (err: any) => {
                 console.log(`Erreur suprresion kanbanstatus : ${err.error['driverError'].detail}`);
                 this.toastService.error(`Error during kanban supression<br><br>${err.error.driverError.detail}`);
             },
             complete : () => {
-                this.toastService.success(" Column deleted !");
                 this.kanbanDeleted.emit(this.kanbanstatus);
             }
         }

--- a/packages/frontend/src/app/services/kanbanstatus.service.ts
+++ b/packages/frontend/src/app/services/kanbanstatus.service.ts
@@ -51,9 +51,9 @@ export class KanbanstatusService {
 
     delete(kanbanstatusId: string): Observable<any> {
         return this.httpClient.delete<any>("/backend/kanbanstatus/"+ kanbanstatusId, this.httpOptions)
-            .pipe(
-                tap((response) => this.log(response)),
-                catchError((error) => this.handleError(error, null))
-            );
+            // .pipe(
+            //     tap((response) => this.log(response)),
+            //     catchError((error) => this.handleError(error, null))
+            // );
     }
 }


### PR DESCRIPTION
Afficher le toast d'erreur en cas d'erreur lors de la tentative de suppression d'un kanban (tâches toujours présentes dans un kanban => suppression pas possible)